### PR TITLE
Uniquely name ontology downloads to prevent collisions

### DIFF
--- a/process.sh
+++ b/process.sh
@@ -57,7 +57,12 @@ fi
 echo '** Downloading relevant ontologies.. **'
 # Temp fix
 while read -r url; do
-  repo=$(echo "$url" | awk -F/ '{print $(NF-3)"-"$(NF-2)}')
+  path_segments=$(echo "$url" | awk -F/ '{print NF}')
+  if [ "$path_segments" -ge 3 ]; then
+    repo=$(echo "$url" | awk -F/ '{print $(NF-3)"-"$(NF-2)}')
+  else
+    repo="default-prefix"
+  fi
   out="$VFB_DOWNLOAD_DIR/${repo}-$(basename "$url")"
   wget -N -O "$out" "$url"
 done < "${CONF_DIR}/vfb_fullontologies.txt"

--- a/process.sh
+++ b/process.sh
@@ -55,7 +55,13 @@ else
 fi
 
 echo '** Downloading relevant ontologies.. **'
-wget -N -P $VFB_DOWNLOAD_DIR -i ${CONF_DIR}/vfb_fullontologies.txt
+# Temp fix
+while read -r url; do
+  repo=$(echo "$url" | awk -F/ '{print $(NF-3)"-"$(NF-2)}')
+  out="$VFB_DOWNLOAD_DIR/${repo}-$(basename "$url")"
+  wget -N -O "$out" "$url"
+done < "${CONF_DIR}/vfb_fullontologies.txt"
+# wget -N -P $VFB_DOWNLOAD_DIR -i ${CONF_DIR}/vfb_fullontologies.txt
 
 echo '** Downloading relevant ontology slices.. **'
 wget -N -P $VFB_SLICES_DIR -i ${CONF_DIR}/vfb_slices.txt


### PR DESCRIPTION
Switch from a single `wget -P` to a URL-loop that:

* Derives a two-segment prefix from each URL path
* Downloads via `wget -O` as `<prefix>-<basename>.owl`
* Eliminates basename clashes (e.g. `CCN20240304.owl` won’t overwrite)

This ensures every OWL file is saved with a distinct, source-identifying filename.
